### PR TITLE
Add workaround needed to make the self-sizing cell work when building for iOS 12 from Xcode 10.0.

### DIFF
--- a/CollectionViewAutoSizingTest/Cell.swift
+++ b/CollectionViewAutoSizingTest/Cell.swift
@@ -15,10 +15,7 @@ class Cell: UICollectionViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
-        self.contentView.translatesAutoresizingMaskIntoConstraints = false
-        let screenWidth = UIScreen.main.bounds.size.width
-        widthConstraint.constant = screenWidth - (2 * 12)
+        
+        contentView.translatesAutoresizingMaskIntoConstraints = false
     }
-
 }

--- a/CollectionViewAutoSizingTest/Cell.swift
+++ b/CollectionViewAutoSizingTest/Cell.swift
@@ -17,5 +17,12 @@ class Cell: UICollectionViewCell {
         super.awakeFromNib()
         
         contentView.translatesAutoresizingMaskIntoConstraints = false
+        
+        // Code below is needed to make the self-sizing cell work when building for iOS 12 from Xcode 10.0:
+        let leftConstraint = contentView.leftAnchor.constraint(equalTo: leftAnchor)
+        let rightConstraint = contentView.rightAnchor.constraint(equalTo: rightAnchor)
+        let topConstraint = contentView.topAnchor.constraint(equalTo: topAnchor)
+        let bottomConstraint = contentView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        NSLayoutConstraint.activate([leftConstraint, rightConstraint, topConstraint, bottomConstraint])
     }
 }

--- a/CollectionViewAutoSizingTest/ViewController.swift
+++ b/CollectionViewAutoSizingTest/ViewController.swift
@@ -9,38 +9,40 @@
 import UIKit
 
 class ViewController: UIViewController, UICollectionViewDataSource {
+    private let leftRightMargin: CGFloat = 12.0
+    
     @IBOutlet weak var collectionView: UICollectionView!
     
-    let randomTexts = ["Aenean dapibus urna a ullamcorper malesuada. Ut tempor.",
-                       "Sed venenatis ligula massa, a vulputate ipsum fringilla eget. Ut justo erat, facilisis id rhoncus cursus, fringilla at.",
+    let strings = [
+        "Aenean dapibus urna a ullamcorper malesuada. Ut tempor.",
+        "Sed venenatis ligula massa, a vulputate ipsum fringilla eget. Ut justo erat, facilisis id rhoncus cursus, fringilla at.",
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum lobortis nibh metus, elementum tempus libero ornare vitae. Etiam sed leo pretium, consectetur turpis non, dapibus purus. Suspendisse potenti. Ut ut eros nunc. Cras nulla justo, porttitor non sapien at, iaculis.",
         "Maecenas pellentesque sed magna in congue. Sed non lacus in mi posuere scelerisque. Aenean.",
-        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras eget ex a velit tincidunt sodales. Donec elementum nisi at enim tempus, et rutrum erat semper. Phasellus ultricies est nec finibus."]
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras eget ex a velit tincidunt sodales. Donec elementum nisi at enim tempus, et rutrum erat semper. Phasellus ultricies est nec finibus."
+    ]
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view, typically from a nib.
+        
         collectionView.register(UINib.init(nibName: "Cell", bundle: nil), forCellWithReuseIdentifier: "Cell")
-        if let flowLayout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
-            flowLayout.estimatedItemSize = CGSize(width: 1,height: 1)
-        }
         collectionView.dataSource = self
-    }
-
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
+        
+        if let flowLayout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
+            flowLayout.estimatedItemSize = UICollectionViewFlowLayoutAutomaticSize
+        }
     }
     
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return randomTexts.count;
+        return strings.count
     }
     
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath) as! Cell
-        cell.descriptionLabel.text = randomTexts[indexPath.row]
+        
+        cell.descriptionLabel.text = strings[indexPath.row]
+        cell.widthConstraint.constant = collectionView.frame.size.width - 2.0 * leftRightMargin
+        
         return cell
     }
-    
 }
 


### PR DESCRIPTION
Hey @tttsunny! I've been looking for a workaround for this issue for a couple of days, and finally found a fix that works for your code sample. The fix is based on this answer on Stack Overflow: https://stackoverflow.com/a/52389062/2024046